### PR TITLE
Fix bug where first 32 cheeps are skipped

### DIFF
--- a/src/Chirp.Infrastructure/Repository/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repository/CheepRepository.cs
@@ -18,7 +18,7 @@ public class CheepRepository : BaseRepository, ICheepRepository
         ICollection<Cheep> cheeps = db.Cheeps.Include(e => e.Author)
             .Include(e => e.Reactions)
             .OrderByDescending(c => c.TimeStamp)
-            .Skip(PageSize * page)
+            .Skip(PageSize * (page - 1))
             .Take(PageSize)
             .ToList();
 

--- a/test/Chirp.InfrastructureTests/RepositoryTests/CheepRepositoryTest.cs
+++ b/test/Chirp.InfrastructureTests/RepositoryTests/CheepRepositoryTest.cs
@@ -44,7 +44,7 @@ public class CheepRepositoryTest{
     public void GetCheepsByPage_ShouldSkipFirst32Cheeps_ReturnXAmountOfCheeps()
     {
         //Act
-        ICollection<Cheep> cheeps = CheepRepository.GetCheepsByPage(1);
+        ICollection<Cheep> cheeps = CheepRepository.GetCheepsByPage(2);
 
         //Assert
         Assert.Equal(2, cheeps.Count);
@@ -53,13 +53,13 @@ public class CheepRepositoryTest{
     [Fact]
     public void DeleteCheepById_ShouldOnlyDeleteSpecifiedCheep()
     {
-        ICollection<Cheep> initialCheeps = CheepRepository.GetCheepsByPage(0);
+        ICollection<Cheep> initialCheeps = CheepRepository.GetCheepsByPage(1);
         Cheep cheep = initialCheeps.First();
         Guid cheepId = cheep.CheepId;
         
         CheepRepository.DeleteCheepById(cheepId);
 
-        ICollection<Cheep> updatedCheeps = CheepRepository.GetCheepsByPage(0);
+        ICollection<Cheep> updatedCheeps = CheepRepository.GetCheepsByPage(1);
         
         //Assert
         Assert.True(initialCheeps.Contains(cheep));


### PR DESCRIPTION
Fixing bug where the first 32 cheeps are skipped because the (pagesize * pageNo) are skipped to show the correct cheeps. The minimum pageNo before this fix was 1 instead of 0. Therefore, the first 32 cheeps got skipped always.  
This is now fixed, and the cheeps are displayed in the correct order.